### PR TITLE
chore(Makefile): add `-t` in build-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build-local:
 	done
 
 build-linux:
-	@docker run --rm                                                                   \
+	@docker run --rm -t                                                                \
 	  -v $(PWD):/go/src/$(ROOT)                                                        \
 	  -w /go/src/$(ROOT)                                                               \
 	  -e GOOS=linux                                                                    \


### PR DESCRIPTION

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

- 在 `build-linux` 的 docker 选项中增加 `-t`
  - 在执行一半时方便退出

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #8 

**Special notes for your reviewer**:

/cc @bbbmj @supereagle @hanxueluo @lsytj0413 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
