### PR TITLE
fix(Makefile): enable race detection in tests only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,8 @@ GOLANGCI_LINT := $(BIN_DIR)/golangci-lint
 # Default golang flags used in build and test
 # -mod=vendor: force go to use the vendor files instead of using the `$GOPATH/pkg/mod`
 # -p: the number of programs that can be run in parallel
-# -race: enable data race detection
 # -count: run each test and benchmark 1 times. Set this flag to disable test cache
-export GOFLAGS ?= -mod=vendor -p=$(CPUS) -race -count=1
+export GOFLAGS ?= -mod=vendor -p=$(CPUS) -count=1
 
 #
 # Define all targets. At least the following commands are required:
@@ -106,7 +105,7 @@ $(GOLANGCI_LINT):
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(BIN_DIR) v1.23.6
 
 test:
-	@go test -coverprofile=coverage.out ./...
+	@go test -race -coverprofile=coverage.out ./...
 	@go tool cover -func coverage.out | tail -n 1 | awk '{ print "Total coverage: " $$3 }'
 
 build-local:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Do not enable the `-race` flag in production, it will affect performance. Introduced in #17

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @supereagle @qianlei90 @hezhizhen 

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
